### PR TITLE
Added pretiffication and schema checks at the sheet level

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
@@ -21,6 +22,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/inflection-0.5.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.42-h02bd663_0.conda
@@ -43,6 +45,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
@@ -51,10 +54,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240909-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.4-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.23.4-py312h12e396e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.6-hc5c86c4_1_cpython.conda
@@ -70,14 +77,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20240913-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
@@ -91,6 +103,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/9d/63a105b5abe736c568ec93207620d3dbb1ba581e4354d23c1b15c77f115f/styleframe-4.2-py3-none-any.whl
       - pypi: .
       osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312h5861a67_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
@@ -103,6 +116,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/inflection-0.5.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
@@ -117,6 +131,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.1-h4b8f8c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py312hb553811_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
@@ -125,10 +140,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.3-py312h98e817e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240909-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.4-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hb553811_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.23.4-py312h669792a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.6-h8f8b54e_1_cpython.conda
@@ -144,14 +163,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20240913-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312hb553811_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h7122b0e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       - pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
@@ -165,6 +189,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/9d/63a105b5abe736c568ec93207620d3dbb1ba581e4354d23c1b15c77f115f/styleframe-4.2-py3-none-any.whl
       - pypi: .
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
@@ -177,6 +202,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/inflection-0.5.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-24_osxarm64_openblas.conda
@@ -191,6 +217,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.1-hc14010f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py312h024a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
@@ -199,10 +226,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcd31e36_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240909-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.4-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.23.4-py312he431725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.6-h739c21a_1_cpython.conda
@@ -218,14 +249,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20240913-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
       - pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
@@ -239,6 +275,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/9d/63a105b5abe736c568ec93207620d3dbb1ba581e4354d23c1b15c77f115f/styleframe-4.2-py3-none-any.whl
       - pypi: .
       win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h275cf98_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
@@ -251,6 +288,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/inflection-0.5.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
@@ -272,6 +310,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.1-py312h49bc9c5_0.conda
@@ -279,12 +318,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py312h72972c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240909-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.4-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.23.4-py312h2615798_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.6-hce54a09_1_cpython.conda
@@ -300,9 +343,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.2.0.20240913-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240917-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
@@ -310,6 +356,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-kbproto-1.0.7-hcd874cb_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.9-h0076a8d_1.conda
@@ -319,6 +366,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
       - pypi: https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl
@@ -363,6 +411,24 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
+- kind: conda
+  name: annotated-types
+  version: 0.7.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
+  md5: 7e9f4612544c8edbfd6afad17f1bd045
+  depends:
+  - python >=3.7
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=hash-mapping
+  size: 18235
+  timestamp: 1716290348421
 - kind: pypi
   name: attrs
   version: 24.2.0
@@ -761,7 +827,7 @@ packages:
   name: ec-jrc-idees
   version: 0.1.0
   path: .
-  sha256: 242f7f6faeb17f0bb504a5ed1257edac19326733278cca7d594aeca4c7cb837d
+  sha256: 29e45b58d75c2e27ceb09cfc3f117c020e6cbce951d87aafb9f536e59a11dc38
   requires_dist:
   - styleframe>=4.2,<5
   requires_python: '>=3.12'
@@ -858,6 +924,24 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 49837
   timestamp: 1726459583613
+- kind: conda
+  name: importlib-metadata
+  version: 8.5.0
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
+  sha256: 7194700ce1a5ad2621fd68e894dd8c1ceaff9a38723e6e0e5298fdef13017b1c
+  md5: 54198435fce4d64d8a89af22573012a8
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-metadata?source=hash-mapping
+  size: 28646
+  timestamp: 1726082927916
 - kind: conda
   name: inflection
   version: 0.5.1
@@ -2041,6 +2125,23 @@ packages:
   size: 3227
   timestamp: 1608166968312
 - kind: conda
+  name: multimethod
+  version: 1.9.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
+  sha256: 7fcfda7b4a1d74205fcfdefd93804226a6eaffc74a319414c7d8d88f9249db3b
+  md5: 48223af3f697ccd9b114adb6a66e0f11
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/multimethod?source=hash-mapping
+  size: 14782
+  timestamp: 1677278842704
+- kind: conda
   name: mypy
   version: 1.11.2
   build: py312h024a12e_0
@@ -2505,6 +2606,47 @@ packages:
   size: 98489
   timestamp: 1725975727109
 - kind: conda
+  name: pandera
+  version: 0.20.4
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.4-hd8ed1ab_0.conda
+  sha256: 62f85c709021bb721101e4baddf1bb293077d70a5ef0f17bb3cc3c1325c868ae
+  md5: 1f5a3edcac6b4ebded70e2bd9871a6a8
+  depends:
+  - pandera-base >=0.20.4,<0.20.5.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 6785
+  timestamp: 1725408304237
+- kind: conda
+  name: pandera-base
+  version: 0.20.4
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.4-pyhd8ed1ab_0.conda
+  sha256: 7b23ec2a4cea4fc2adc10828829fcb044c196719d0dd9ca63f4577b1855eb6c8
+  md5: c2a59e20377cedcfa4a4dfa98fa7f36e
+  depends:
+  - multimethod <=1.10.0
+  - numpy >=1.19.0
+  - packaging >=20.0
+  - pandas >=1.2.0
+  - pydantic >=1.5.0
+  - python >=3.8
+  - typeguard
+  - typing_inspect >=0.6.0
+  - wrapt
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pandera?source=hash-mapping
+  size: 150012
+  timestamp: 1725408301583
+- kind: conda
   name: pluggy
   version: 1.5.0
   build: pyhd8ed1ab_0
@@ -2667,6 +2809,112 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 105098
   timestamp: 1711811634025
+- kind: conda
+  name: pydantic
+  version: 2.9.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.9.2-pyhd8ed1ab_0.conda
+  sha256: 1b7b0dc9f6af4da156bf22b0263be70829364a08145c696d3670facff2f6441a
+  md5: 1eb533bb8eb2199e3fef3e4aa147319f
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.23.4
+  - python >=3.7
+  - typing-extensions >=4.6.1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=hash-mapping
+  size: 300649
+  timestamp: 1726601202431
+- kind: conda
+  name: pydantic-core
+  version: 2.23.4
+  build: py312h12e396e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.23.4-py312h12e396e_0.conda
+  sha256: 365fde689865087b2a9da636f36678bd59617b324ce7a538b4806e90602b20f1
+  md5: 0845ab52d4ea209049129a6a91bc74ba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1611784
+  timestamp: 1726525286507
+- kind: conda
+  name: pydantic-core
+  version: 2.23.4
+  build: py312h2615798_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.23.4-py312h2615798_0.conda
+  sha256: cda5f2ea2fb8b1aa91b744aadec269ec3060832106242873639df205258aac62
+  md5: 94169f56c3ad3d070248c73f71371944
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1566768
+  timestamp: 1726526372511
+- kind: conda
+  name: pydantic-core
+  version: 2.23.4
+  build: py312h669792a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.23.4-py312h669792a_0.conda
+  sha256: 46b17406772d7403ce454c1005e493a2723a189403dd2a70a3566ac4b1f82a4a
+  md5: 14806afd8ed78812d83e8b9ea4b549c0
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1535259
+  timestamp: 1726525537029
+- kind: conda
+  name: pydantic-core
+  version: 2.23.4
+  build: py312he431725_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.23.4-py312he431725_0.conda
+  sha256: d6edd3d0f9e701c8299519d412ad3dc900c7d893a134f2582203cf43585decca
+  md5: 3148052477686acc581b20a34b478eeb
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1431747
+  timestamp: 1726525575527
 - kind: conda
   name: pysocks
   version: 1.7.1
@@ -3385,6 +3633,28 @@ packages:
   size: 15940
   timestamp: 1644342331069
 - kind: conda
+  name: typeguard
+  version: 4.3.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
+  sha256: 1bbf56b43b7a4f696e6d4027404865519bc676760129580ba558555dedfdcfa9
+  md5: 10f49ee1beb82947170c5a5e1a8c0ef3
+  depends:
+  - importlib-metadata >=3.6
+  - python >=3.8
+  - typing-extensions >=4.10.0
+  constrains:
+  - pytest >=7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typeguard?source=hash-mapping
+  size: 34547
+  timestamp: 1721540525136
+- kind: conda
   name: types-pytz
   version: 2024.2.0.20240913
   build: pyhd8ed1ab_0
@@ -3417,6 +3687,22 @@ packages:
   size: 25178
   timestamp: 1726556396066
 - kind: conda
+  name: typing-extensions
+  version: 4.12.2
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
+  depends:
+  - typing_extensions 4.12.2 pyha770c72_0
+  license: PSF-2.0
+  license_family: PSF
+  purls: []
+  size: 10097
+  timestamp: 1717802659025
+- kind: conda
   name: typing_extensions
   version: 4.12.2
   build: pyha770c72_0
@@ -3433,6 +3719,25 @@ packages:
   - pkg:pypi/typing-extensions?source=hash-mapping
   size: 39888
   timestamp: 1717802653893
+- kind: conda
+  name: typing_inspect
+  version: 0.9.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
+  sha256: 16e0b825c138e14ebc84623248d91d93a8cff29bb93595cc4aa46ca32f24f1de
+  md5: 9e924b76b91908a17e28a19a0ab88687
+  depends:
+  - mypy_extensions >=0.3.0
+  - python >=3.5
+  - typing_extensions >=3.7.4
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspect?source=hash-mapping
+  size: 14906
+  timestamp: 1685820229594
 - kind: conda
   name: tzdata
   version: 2024a
@@ -3553,6 +3858,86 @@ packages:
   - pkg:pypi/win-inet-pton?source=hash-mapping
   size: 8191
   timestamp: 1667051294134
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py312h024a12e_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312h024a12e_1.conda
+  sha256: 54a5d3d9e1b45022b28c5ca3ceaa7ec2db4a40968b2b556804becfdff98f4efe
+  md5: f97c9abfeb8292f5f8353607ca8a1127
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 59642
+  timestamp: 1724958200454
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py312h4389bb4_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py312h4389bb4_1.conda
+  sha256: b136f99c616ef39243139929588030ba7fb48a3e518265513206cff405c3e5f4
+  md5: d6f56554649b5cc8fff12efb657ea797
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 60856
+  timestamp: 1724958453066
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py312h66e93f0_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h66e93f0_1.conda
+  sha256: 3a15a399eb61a999f0f14b4d243acc14e2dff1ead92ef52fcff30c84be89b21c
+  md5: 2eebcffe80e2a7bb2f0a77e621a7f124
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 62624
+  timestamp: 1724958046744
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py312hb553811_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312hb553811_1.conda
+  sha256: 31e3fdd934cdb8ac47764d1daf13edddd7844a17b229e8ef438fc16e06576b00
+  md5: 6385725172f8712d54b5af6b86bf8236
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 58290
+  timestamp: 1724958107514
 - kind: conda
   name: xarray
   version: 2024.9.0
@@ -3808,6 +4193,23 @@ packages:
   purls: []
   size: 63274
   timestamp: 1641347623319
+- kind: conda
+  name: zipp
+  version: 3.20.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
+  sha256: 1e84fcfa41e0afdd87ff41e6fbb719c96a0e098c1f79be342293ab0bd8dea322
+  md5: 4daaed111c05672ae669f7036ee5bba3
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/zipp?source=hash-mapping
+  size: 21409
+  timestamp: 1726248679175
 - kind: conda
   name: zstandard
   version: 0.23.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ requests = ">=2.32.3,<3"
 pytest = ">=8.3.3,<9"
 ruff = ">=0.6.5,<0.7"
 mypy = ">=1.11.2,<2"
+pandera = ">=0.20.4,<0.21"
 
 # Environments
 [tool.pixi.environments]

--- a/src/ec_jrc_idees/config/Transport.yaml
+++ b/src/ec_jrc_idees/config/Transport.yaml
@@ -1,62 +1,108 @@
-prefix_cols:
+validation:
+  expected:
+    category:
+      - Passenger
+      - Freight
+    subcategory:
+      - Road
+    vehicle_type:
+      - Powered two-wheelers
+      - Passenger cars
+      - Motor coaches, buses and trolley buses
+      - Light commercial vehicles
+      - Heavy goods vehicles
+    vehicle_subtype:
+      - Gasoline engine
+      - Diesel oil engine
+      - LPG engine
+      - Natural gas engine
+      - Plug-in hybrid electric
+      - Battery electric vehicles
+      - Domestic
+      - International
+  optional:
+    carrier:
+      - Gasoline
+      - Diesel
+      - Natural gas
+      - LPG
+      - Electricity
+remap:
+  category: {"Passenger transport": "Passenger", "Freight transport": "Freight"}
+  vehicle_type: {"Powered 2-wheelers": "Powered two-wheelers"}
 sheets:
   TrRoad_act:
     prefix_cols:
     sections:
       RoadVKM:
+        variable: "DistanceDriven"
+        units:
+          idees: "mio km"
+          tidy: "million km"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "million km"
-          variable: "DistanceDriven"
+          vehicle_subtype:
   TrRoad_tech:
     prefix_cols:
     sections:
       RoadTotalStock:
+        variable: "TotalStock"
+        units:
+          idees: "vehicles"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "vehicles"
-          variable: "TotalStock"
+          vehicle_subtype:
       RoadTotalStockTestEfficiency:
+        units:
+          idees: "kgoe/100 km"
+        variable: "TotalStockTestEfficiency"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "kgoe per 100 km"
-          variable: "TotalStockTestEfficiency"
+          vehicle_subtype:
       RoadTotalStockTestDiscrepancy:
+        units:
+          idees: "ratio"
+        variable: "TotalStockTestDiscrepancy"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "ratio"
-          variable: "TotalStockTestDiscrepancy"
+          vehicle_subtype:
       RoadNewRegistrations:
+        units:
+         idees:
+         tidy: "vehicles"
+        variable: "NewRegistrations"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "vehicles"
-          variable: "NewRegistrations"
+          vehicle_subtype:
       RoadNewRegistrationsTestEfficiency:
+        units:
+          idees: "kgoe/100 km"
+        variable: "NewRegistrationsTestEfficiency"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
-          units: "kgoe per 100 km"
-          variable: "NewRegistrationsTestEfficiency"
+          vehicle_subtype:
   TrRoad_ene:
     prefix_cols:
     sections:
       RoadEnergyConsumption:
+        units:
+          idees: "ktoe"
+        variable: "TotalEnergyConsumption"
         template_columns:
           category:
           subcategory: "Road"
           vehicle_type:
           vehicle_subtype:
           carrier:
-          units: "ktoe"
-          variable: "TotalEnergyConsumption"

--- a/src/ec_jrc_idees/generics.py
+++ b/src/ec_jrc_idees/generics.py
@@ -17,7 +17,6 @@ STYLE_FEATURES = Literal[
 ]
 
 
-
 class IDEESSection:
     """Generic IDEES section within a sheet."""
 
@@ -211,12 +210,12 @@ class IDEESSheet:
             template_columns = {name: Column(str) for name in cnf["template_columns"]}
             data_columns = {
                 "year": Column(int, checks=Check.isin(expected_years)),
-                variable_col: Column(float, nullable=True)
+                variable_col: Column(float, nullable=True),
             }
             schema = DataFrameSchema(
                 columns=template_columns | data_columns,
                 index=Index(int, unique=True),
-                ordered=True
+                ordered=True,
             )
             schema.validate(tidy_df)
 

--- a/src/ec_jrc_idees/transport.py
+++ b/src/ec_jrc_idees/transport.py
@@ -67,7 +67,7 @@ class RoadSection(IDEESSection):
     """Adds generic calculations specific to Road transport."""
 
     @override
-    def check(self):
+    def specific_check(self):
         years = self.annual_df.columns
         aggregates = [
             get_total_aggregates(self.idees_text, self.style),
@@ -124,7 +124,7 @@ class RoadSectionNoCarrierNoAggregates(RoadSectionNoCarriers):
     """Generic data extraction for no carrier sections without aggregates."""
 
     @override
-    def check(self):
+    def specific_check(self):
         # Sections with ratios or rates have no aggregates for testing.
         # Instead, rely on their matching shape with other sections and
         # check that all gathered values can be interpreted as numeric.
@@ -256,22 +256,12 @@ class TrRoad_act(IDEESSheet):
     SHEET_NAME = "TrRoad_act"
     SECTION_CLEANERS = [RoadVKM]
 
-    @override
-    def check(self):
-        # TODO: add checks once all transport files are processed.
-        pass
-
 
 class TrRoad_ene(IDEESSheet):
     """Transport Road energy."""
 
     SHEET_NAME = "TrRoad_ene"
     SECTION_CLEANERS = [RoadEnergyConsumption]
-
-    @override
-    def check(self):
-        # TODO: add checks once all transport files are processed.
-        pass
 
 
 class TrRoad_tech(IDEESSheet):
@@ -285,11 +275,6 @@ class TrRoad_tech(IDEESSheet):
         RoadNewRegistrations,
         RoadNewRegistrationsTestEfficiency,
     ]
-
-    @override
-    def check(self):
-        # TODO: add checks once all transport files are processed.
-        pass
 
 
 class TransportFile(IDEESFile):

--- a/src/ec_jrc_idees/utils.py
+++ b/src/ec_jrc_idees/utils.py
@@ -1,5 +1,6 @@
 """Generic utility functions that may be used anywhere."""
 
+from pathlib import Path
 from typing import Literal, NamedTuple
 
 import inflection
@@ -9,7 +10,11 @@ from styleframe import StyleFrame
 STYLE_FEATURES = Literal[
     "bg_color", "bold", "font_color", "underline", "border_type", "indent"
 ]
+BRACKETS = Literal["()", "[]", "<>"]
 
+MIN_YEAR = 2000
+MAX_YEAR_V1 = 2015
+MAX_YEAR_V2 = 2021
 
 class Metadata(NamedTuple):
     """Contains important details contained in the filename."""
@@ -19,8 +24,9 @@ class Metadata(NamedTuple):
     country_eurostat: str
 
 
-def get_filename_metadata(filename: str) -> Metadata:
+def get_filename_metadata(filepath: str | Path) -> Metadata:
     """Get metadata from the JRC-IDEES filenames."""
+    filename = Path(filepath).name
     data = filename.split("-")[-1].split("_")
     metadata = Metadata(
         version=int(data[0]), file=data[1], country_eurostat=data[-1].split(".")[0]
@@ -28,11 +34,11 @@ def get_filename_metadata(filename: str) -> Metadata:
     return metadata
 
 
-def get_unit_in_parenthesis(text: str) -> str:
+def get_units_in_brackets(text: str, brackets: BRACKETS = "()") -> str:
     """Read text within a parenthesis as unit and standardize it."""
-    if text.count("(") != 1 or text.count(")") != 1:
-        raise ValueError("Invalid string: must be in the for of 'Something (unit)'.")
-    unit = standardize_unit(text[text.find("(") + 1 : text.find(")")])
+    if text.count(brackets[0]) != 1 or text.count(brackets[-1]) != 1:
+        raise ValueError("Invalid string: must be in the form of 'Something (unit)'.")
+    unit = text[text.find(brackets[0]) + 1 : text.find(brackets[-1])]
     return unit
 
 
@@ -44,7 +50,6 @@ def standardize_unit(unit: str):
             unit = unit.replace("/", "per")
         else:
             unit = unit.replace("/", " per ")
-    unit = unit.replace(" ", "_")
     unit = inflection.underscore(unit)
     return unit
 
@@ -66,3 +71,14 @@ def get_style_feature(
     if rows is not None:
         series = series[rows]
     return series
+
+
+def get_expected_years(metadata: Metadata) -> list[int]:
+    """Get a range of years for this sheet."""
+    if metadata.version == MAX_YEAR_V1:
+        max_year = MAX_YEAR_V1
+    elif metadata.version == MAX_YEAR_V2:
+        max_year = MAX_YEAR_V2
+    else:
+        raise ValueError(f"Invalid version configured: '{metadata.version}'")
+    return list(range(MIN_YEAR, max_year + 1))

--- a/src/ec_jrc_idees/utils.py
+++ b/src/ec_jrc_idees/utils.py
@@ -16,6 +16,7 @@ MIN_YEAR = 2000
 MAX_YEAR_V1 = 2015
 MAX_YEAR_V2 = 2021
 
+
 class Metadata(NamedTuple):
     """Contains important details contained in the filename."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,26 +8,26 @@ import pytest
 from ec_jrc_idees.parser import EasyIDEES
 
 
-@pytest.fixture(params=[2021, 2015])
+@pytest.fixture(params=[2021, 2015], scope="session")
 def version(request) -> int:
     """Dataset version to parse."""
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def easy_idees(version: int) -> EasyIDEES:
     """Construct a parser per dataset year."""
     easy = EasyIDEES(version)
     return easy
 
 
-@pytest.fixture(params=["DE"])
+@pytest.fixture(params=["DE"], scope="session")
 def country(request) -> str:
     """Select the country to process."""
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def zip_path(easy_idees: EasyIDEES, country: str):
     """Download zip file for this country and version."""
     version = easy_idees.version
@@ -40,7 +40,7 @@ def zip_path(easy_idees: EasyIDEES, country: str):
     return zipfile
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def country_path(easy_idees: EasyIDEES, zip_path: Path, country: str) -> Path:
     """Folder where all country files are placed."""
     country_dir = zip_path.parent / f"{country}"

--- a/tests/generic_test.py
+++ b/tests/generic_test.py
@@ -22,8 +22,16 @@ class Section(IDEESSection):
         self.tidy_df = DUMMY_TIDY_DF
 
     @override
-    def check(self):
-        return True
+    def specific_check(self):
+        pass
+
+    @override
+    def generic_check(self):
+        pass
+
+    @override
+    def prettify(self) -> None:
+        pass
 
 
 class Sheet(IDEESSheet):
@@ -34,7 +42,7 @@ class Sheet(IDEESSheet):
 
     @override
     def check(self):
-        return True
+        pass
 
 
 class File(IDEESFile):
@@ -44,7 +52,7 @@ class File(IDEESFile):
 
     @override
     def check(self):
-        return True
+        pass
 
 
 @pytest.fixture

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -22,21 +22,32 @@ def test_filename_metadata(filename):
 
 
 @pytest.mark.parametrize(
-    ("text", "expected"),
+    ("text", "expected", "method"),
     [
-        ("Stock of vehicles - total (vehicles)", "vehicles"),
-        ("CO2 emissions (kt CO2)", "kt_co2"),
-        ("something subsector (kt of CO2)", "kt_co2"),
-        ("Market shares (%)", "%"),
-        ("Emission intensity (kt of CO2 / ktoe)", "kt_co2_per_ktoe"),
-        ("yadda (toe useful/t of output) yadda", "toe_useful_per_t_output"),
-        ("thing (toe useful / t of output)", "toe_useful_per_t_output"),
+        ("Stock of vehicles - total (vehicles)", "vehicles", "()"),
+        ("CO2 emissions [kt CO2]", "kt CO2", "[]"),
+        ("Emission intensity <kt of CO2 / ktoe>", "kt of CO2 / ktoe", "<>"),
+        ("yadda (toe useful/t of output) yadda", "toe useful/t of output", "()"),
     ],
 )
-def test_unit_extraction(text, expected):
+def test_unit_extraction(text, expected, method):
     """Units within a cell should be cleaned approprietly."""
-    assert utils.get_unit_in_parenthesis(text) == expected
+    assert utils.get_units_in_brackets(text, method) == expected
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("vehicles", "vehicles"),
+        ("kt CO2", "kt co2"),
+        ("kt of CO2", "kt co2"),
+        ("%", "%"),
+        ("kt of CO2 / ktoe", "kt co2 per ktoe"),
+        ("toe useful/t of output", "toe useful per t output"),
+        ("toe useful / t of output", "toe useful per t output"),
+    ],
+)
+def test_unit_standardisation(text, expected):
+    """Unit standardisation should make units slightly more readable."""
 
 @pytest.mark.parametrize("prefix", [{"foo": "bar", "empty": ""}])
 def test_prefix_columns(prefix):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -34,6 +34,7 @@ def test_unit_extraction(text, expected, method):
     """Units within a cell should be cleaned approprietly."""
     assert utils.get_units_in_brackets(text, method) == expected
 
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
@@ -48,6 +49,7 @@ def test_unit_extraction(text, expected, method):
 )
 def test_unit_standardisation(text, expected):
     """Unit standardisation should make units slightly more readable."""
+
 
 @pytest.mark.parametrize("prefix", [{"foo": "bar", "empty": ""}])
 def test_prefix_columns(prefix):


### PR DESCRIPTION
All transport files are passed through a schema at the sheet level using `pandera`.
This ensures typing, order and value ranges in certain cases.

Things left to do are:
- remapping final values at the file level for pre defined columns.
- Running a last schema check to ensure technology names and carrier names do not deviate from a given list.
- Saving the final results.